### PR TITLE
Start the webserver and block

### DIFF
--- a/Nostra.Relay/Program.fs
+++ b/Nostra.Relay/Program.fs
@@ -182,10 +182,5 @@ let logger =
 let main argv =
     let cts = new CancellationTokenSource()
     let conf = { defaultConfig with cancellationToken = cts.Token; logger = logger }
-    let listening, server = startWebServerAsync conf app
-
-    Async.Start(server, cts.Token)
-    Console.ReadKey true |> ignore  
-    cts.Cancel()
-
+    startWebServer conf app
     0 // return an integer exit code    


### PR DESCRIPTION
Use blocking call because it makes no sense to wait for a key to be pressed when this runs as a daemon.