### PR TITLE
Fix duplicate subscription ID crash

### DIFF
--- a/Nostra.Relay/MessageProcessing.fs
+++ b/Nostra.Relay/MessageProcessing.fs
@@ -49,10 +49,9 @@ let canPersistEvent (event : Event) = result {
 let verifyCanSubscribe subscriptionId filters (subscriptionStore : SubscriptionStore) = result {
     let filterCount = Seq.length filters
     do! Result.requireTrue (noticeError "Too many filters") (filterCount < 5)
+    let isNewSubscription = not (subscriptionStore.ContainsKey subscriptionId)
     let subscriptionCount = Seq.length subscriptionStore
-    do! Result.requireTrue (noticeError "Too many subscription") (subscriptionCount < 10)
-    let exists, existingFilters = subscriptionStore.TryGetValue(subscriptionId)
-    do! Result.requireFalse (noticeError "Duplicated subscription") (exists && existingFilters = filters)
+    do! Result.requireTrue (noticeError "Too many subscriptions") (subscriptionCount < 10 || not isNewSubscription)
     }
 
 let processRequest (env : Context) (subscriptionStore : SubscriptionStore) requestText = asyncResult {
@@ -72,7 +71,7 @@ let processRequest (env : Context) (subscriptionStore : SubscriptionStore) reque
 
     | CMSubscribe(subscriptionId, filters) ->
         do! (verifyCanSubscribe subscriptionId filters subscriptionStore)
-        subscriptionStore.Add( subscriptionId, filters )
+        subscriptionStore[subscriptionId] <- filters
         let! matchingEvents =
             filterEvents env.eventStore.fetchEvents filters DateTime.Now
             |> AsyncResult.mapError (fun ec -> noticeError "Something was wrong.")


### PR DESCRIPTION
Per NIP-01, clients can reuse subscription IDs to replace/update their subscriptions. The relay was crashing with "An item with the same key has already been added" because Dictionary.Add() throws on duplicates.

Changes:
- Use indexed assignment instead of Add() to allow upserts
- Only enforce subscription limit for new subscriptions
- Remove incorrect "Duplicated subscription" error